### PR TITLE
Build app with app-build-suite

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,4 @@
+replace-chart-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/hello-world-app
+destination: ./build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.10.0
+  architect: giantswarm/architect@1.0.0
 
 jobs:
   build:
@@ -36,6 +36,7 @@ workflows:
 
       - architect/push-to-app-catalog:
           context: "architect"
+          executor: "app-build-suite"
           name: "package and push chart to app catalog"
           app_catalog: "giantswarm-playground-catalog"
           app_catalog_test: "giantswarm-playground-test-catalog"

--- a/helm/hello-world-app/templates/rbac.yaml
+++ b/helm/hello-world-app/templates/rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-cluster-role
@@ -14,7 +14,7 @@ rules:
     resourceNames:
       - {{ tpl .Values.resource.default.name . }}-psp
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-cluster-role-binding


### PR DESCRIPTION
This PR enables building and pushing the app chart with app-build-suite in ci

ping @giantswarm/team-halo-engineers 