### PR TITLE
Add team label and cleanup Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- `Chart.yaml` includes now more metadata info, including explicitely set `appVersion`
+- `_templates.yaml` is introduced and supports team label handling
+
 ## [0.2.0] - 2022-01-19
 
 ## Added

--- a/helm/hello-world-app/Chart.yaml
+++ b/helm/hello-world-app/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hello-world-app
 version: "0.2.1"
-appVersion: "latest"
+appVersion: "0.1.0"
 home: https://github.com/giantswarm/hello-world-app
 description: A chart that deploys a basic hello world site and lets you test values merging of user values configmap and secrets.
 icon: https://s.giantswarm.io/app-icons/1/png/hello-world-app-light.png

--- a/helm/hello-world-app/Chart.yaml
+++ b/helm/hello-world-app/Chart.yaml
@@ -1,8 +1,18 @@
 apiVersion: v2
 name: hello-world-app
-version: "0.1.0"
+version: "0.2.1"
+appVersion: "latest"
 home: https://github.com/giantswarm/hello-world-app
 description: A chart that deploys a basic hello world site and lets you test values merging of user values configmap and secrets.
 icon: https://s.giantswarm.io/app-icons/1/png/hello-world-app-light.png
+keywords:
+  - hello-world
+  - demo
+  - webapp
+sources:
+  - https://github.com/giantswarm/hello-world-app
+  - https://github.com/giantswarm/helloworld
+maintainers:
+  - name: Giant Swarm - Honeybadger
 annotations:
   application.giantswarm.io/team: "honeybadger"

--- a/helm/hello-world-app/templates/_helpers.yaml
+++ b/helm/hello-world-app/templates/_helpers.yaml
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hello-world-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hello-world-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hello-world-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hello-world-app.labels" -}}
+helm.sh/chart: {{ include "hello-world-app.chart" . }}
+app: "{{ template "hello-world-app.name" . }}"
+app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+helm.sh/chart: "{{ template "hello-world-app.chart" . }}"
+giantswarm.io/service-type: "managed"
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+{{ include "hello-world-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hello-world-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hello-world-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hello-world-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hello-world-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/hello-world-app/templates/deployment.yaml
+++ b/helm/hello-world-app/templates/deployment.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      {{- include "hello-world-app.selectorLabels" . | nindent 4 }}
+      {{- include "hello-world-app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "hello-world-app.labels" . | nindent 4 }}
+        {{- include "hello-world-app.labels" . | nindent 8 }}
     spec:
       affinity:
         podAntiAffinity:

--- a/helm/hello-world-app/templates/deployment.yaml
+++ b/helm/hello-world-app/templates/deployment.yaml
@@ -3,16 +3,16 @@ kind: Deployment
 metadata:
   name: {{ tpl .Values.resource.default.name . }}
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      app: {{ tpl .Values.resource.default.name . }}
+      {{- include "hello-world-app.selectorLabels" . | nindent 4 }}
   template:
     metadata:
       labels:
-        app: {{ tpl .Values.resource.default.name . }}
+        {{- include "hello-world-app.labels" . | nindent 4 }}
     spec:
       affinity:
         podAntiAffinity:
@@ -59,6 +59,8 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-pdb
+  labels:
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/hello-world-app/templates/ingress.yaml
+++ b/helm/hello-world-app/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
   {{- if .Values.obtainTLSCertificate }}
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"

--- a/helm/hello-world-app/templates/psp.yaml
+++ b/helm/hello-world-app/templates/psp.yaml
@@ -3,7 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-psp
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/helm/hello-world-app/templates/rbac.yaml
+++ b/helm/hello-world-app/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-role
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
@@ -16,7 +16,7 @@ kind: RoleBinding
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-role-binding
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name . }}-service-account

--- a/helm/hello-world-app/templates/service-account.yaml
+++ b/helm/hello-world-app/templates/service-account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-service-account
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}

--- a/helm/hello-world-app/templates/service.yaml
+++ b/helm/hello-world-app/templates/service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-service
   labels:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    app: {{ tpl .Values.resource.default.name . }}
+    {{- include "hello-world-app.selectorLabels" . | nindent 4 }}

--- a/helm/hello-world-app/values.yaml
+++ b/helm/hello-world-app/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: 'quay.io'
   name: 'giantswarm/helloworld'
-  tag: 'latest'
+  tag: '0.2.0'
 
 resource:
   default:


### PR DESCRIPTION
We own this app and it should be our "go to" example of configuring an app. This adds some missing annotations and `Chart.yaml` attributes.