### PR TITLE
Update the APP version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update App version to `0.2.1`.
+
 ## [2.3.1] - 2024-01-29
 
 ### Fixed

--- a/helm/hello-world/Chart.yaml
+++ b/helm/hello-world/Chart.yaml
@@ -3,7 +3,7 @@ name: hello-world
 description: A chart that deploys a basic hello world site and lets you test values merging of user values configmap and secrets.
 type: application
 version: 2.3.1
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 home: https://github.com/giantswarm/hello-world-app
 icon: https://s.giantswarm.io/app-icons/1/png/hello-world-app-light.png
 keywords:


### PR DESCRIPTION
this app is used as part of e2e to test if ingress works as expected 

but the original `helloworld` app  docker image was not pushed to China registries which is now fixed but only with the latest image version `0.2.1` so updating the chart here to include the latest image.