### PR TITLE
chore: add Artifact Hub metadata to Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Artifact Hub metadata in `Chart.yaml`: `maintainers`, `artifacthub.io/license` and `artifacthub.io/links` annotations. ([roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940))
+
 ## [3.0.2] - 2026-03-31
 
 ### Fixed

--- a/helm/hello-world/Chart.yaml
+++ b/helm/hello-world/Chart.yaml
@@ -12,7 +12,16 @@ keywords:
   - testing
 sources:
   - https://github.com/giantswarm/helloworld
+maintainers:
+  - name: Giant Swarm
+    url: https://github.com/giantswarm
 annotations:
   io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "false"
   io.giantswarm.application.team: honeybadger
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Support
+      url: https://github.com/giantswarm/hello-world-app/issues
+    - name: Giant Swarm
+      url: https://www.giantswarm.io


### PR DESCRIPTION
## What
Adds Artifact Hub metadata to the chart:
- `maintainers` (Giant Swarm)
- `artifacthub.io/license: Apache-2.0`
- `artifacthub.io/links` (support + giantswarm.io)

## Why
PoC for publishing our charts on Artifact Hub from the gsoci OCI registry — see giantswarm/roadmap#3940. hello-world is one of the two representative charts.

No template/values changes; `helm lint` passes.