### PR TITLE
fix: allow full affinity and podSecurityContext values in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow full `affinity` and `podSecurityContext` values by setting `additionalProperties: true` on their `$ref`-based schema entries, which were previously rejecting all keys (e.g. `affinity.podAntiAffinity`).
+
 ## [3.0.3] - 2026-07-15
 
 ### Added

--- a/helm/hello-world/values.schema.json
+++ b/helm/hello-world/values.schema.json
@@ -6,7 +6,7 @@
             "description": "Affinity rules for pod scheduling",
             "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity",
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "autoscaling": {
             "description": "This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/",
@@ -71,7 +71,7 @@
                     "type": "string"
                 },
                 "tag": {
-                    "description": "Overrides the image tag whose default is the chart appVersion.",
+                    "description": "Container image tag.",
                     "type": "string"
                 }
             },
@@ -220,7 +220,7 @@
             "description": "Pod security context configuration",
             "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext",
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "readinessProbe": {
             "description": "Readiness probe configuration",

--- a/helm/hello-world/values.yaml
+++ b/helm/hello-world/values.yaml
@@ -57,7 +57,7 @@ podAnnotations: {}
 # -- This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-# @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext
+# @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext; additionalProperties: true
 # -- Pod security context configuration
 podSecurityContext: {}
   # fsGroup: 2000
@@ -335,7 +335,7 @@ nodeSelector: {}
 # -- Tolerations for pod scheduling
 tolerations: []
 
-# @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity
+# @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity; additionalProperties: true
 # -- Affinity rules for pod scheduling
 affinity: {}
 


### PR DESCRIPTION
Fixes a cluster-test-suites e2e failure on the scale test:

```
HelmRelease 't-jlgehsadtnvar9decx-scale-hello-world' not yet ready: InstallFailed -
Helm install failed for release giantswarm/scale-hello-world with chart hello-world@3.0.3:
values don't meet the specifications of the schema(s) in the following chart(s):
hello-world:
- at '/affinity': additional properties 'podAntiAffinity' not allowed
[FAILED] in [BeforeEach] - /app/internal/common/scale.go:86
```

`affinity` and `podSecurityContext` are empty `{}` in `values.yaml` and validated via a k8s `$ref`. The generator (`noAdditionalProperties: true`) stamped `additionalProperties: false` next to the `$ref`, which under JSON Schema 2020-12 rejects every key — so `affinity.podAntiAffinity` was refused.

The referenced k8s definitions already enforce `additionalProperties: false` internally, so setting `additionalProperties: true` on these two properties restores full validation without losing strictness (unknown keys are still rejected by the ref'd definition).

Fixed at the source via `@schema ... ; additionalProperties: true` annotations in `values.yaml` and regenerated the schema.
