### PR TITLE
feat: add crash mode and extraEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `crash` values to opt into staged failure injection for demos and testing: `crash.enabled` turns on a deliberate memory leak that drives a repeating OOMKill, with `crash.rateBytesPerSec` and `crash.gracePeriod` for tuning. Disabled by default.
+- Add `extraEnv` value to inject additional environment variables into the container. Defaults to `[]`, so rendered output is unchanged for existing users.
+
 ## [3.0.4] - 2026-07-22
 
 ### Fixed

--- a/helm/hello-world/README.md
+++ b/helm/hello-world/README.md
@@ -90,6 +90,11 @@ A chart that deploys a basic hello world site and lets you test values merging o
 | strategy.rollingUpdate.maxSurge | int | `1` | Maximum number of pods that can be created above the desired replica count |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
+| extraEnv | list | `[]` | Additional environment variables to inject into the container. |
+| crash | object | `{"enabled":false,"gracePeriod":"30s","rateBytesPerSec":1048576}` | Staged, deliberate failure injection for demos and testing. When enabled the container leaks memory until the kubelet OOMKills it, on a loop. This is off by default and must not be enabled in production. |
+| crash.enabled | bool | `false` | Enable crash mode: a deliberate memory leak that drives a repeating OOMKill. Off by default. |
+| crash.rateBytesPerSec | int | `1048576` | Memory leak rate in bytes per second (default 1 MiB/s). |
+| crash.gracePeriod | string | `"30s"` | Grace period before leaking starts, so the pod reaches Ready first. Any Go duration. |
 | nodeSelector | object | `{}` | Node selector for pod scheduling |
 | tolerations | list | `[]` | Tolerations for pod scheduling |
 | affinity | object | `{}` | Affinity rules for pod scheduling |

--- a/helm/hello-world/templates/deployment.yaml
+++ b/helm/hello-world/templates/deployment.yaml
@@ -46,6 +46,17 @@ spec:
             secretKeyRef:
               name: {{ include "hello-world.fullname" . }}
               key: secret-key
+        {{- if .Values.crash.enabled }}
+        - name: MEMORY_LEAK_ENABLED
+          value: "true"
+        - name: MEMORY_LEAK_RATE_BYTES_PER_SEC
+          value: {{ .Values.crash.rateBytesPerSec | int64 | quote }}
+        - name: MEMORY_LEAK_GRACE_PERIOD
+          value: {{ .Values.crash.gracePeriod | quote }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8080

--- a/helm/hello-world/values.schema.json
+++ b/helm/hello-world/values.schema.json
@@ -41,6 +41,33 @@
             },
             "additionalProperties": false
         },
+        "crash": {
+            "description": "Staged, deliberate failure injection for demos and testing. When enabled the container leaks memory until the kubelet OOMKills it, on a loop. This is off by default and must not be enabled in production.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable crash mode: a deliberate memory leak that drives a repeating OOMKill. Off by default.",
+                    "type": "boolean"
+                },
+                "gracePeriod": {
+                    "description": "Grace period before leaking starts, so the pod reaches Ready first. Any Go duration.",
+                    "type": "string"
+                },
+                "rateBytesPerSec": {
+                    "description": "Memory leak rate in bytes per second (default 1 MiB/s).",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "additionalProperties": false
+        },
+        "extraEnv": {
+            "description": "Additional environment variables to inject into the container.",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVar"
+            }
+        },
         "fullnameOverride": {
             "description": "Override the full name of the chart",
             "type": "string"
@@ -663,6 +690,73 @@
                     },
                     "additionalProperties": false
                 },
+                "io.k8s.api.core.v1.ConfigMapKeySelector": {
+                    "description": "Selects a key from a ConfigMap.",
+                    "type": "object",
+                    "required": [
+                        "key"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "io.k8s.api.core.v1.EnvVar": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                            "type": "string"
+                        },
+                        "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVarSource"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "io.k8s.api.core.v1.EnvVarSource": {
+                    "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                    "type": "object",
+                    "properties": {
+                        "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
+                        },
+                        "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+                        },
+                        "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+                        },
+                        "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretKeySelector"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "io.k8s.api.core.v1.ExecAction": {
                     "description": "ExecAction describes a \"run in container\" action.",
                     "type": "object",
@@ -837,6 +931,24 @@
                             "items": {
                                 "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
                             }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "io.k8s.api.core.v1.ObjectFieldSelector": {
+                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                    "type": "object",
+                    "required": [
+                        "fieldPath"
+                    ],
+                    "properties": {
+                        "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -1086,6 +1198,28 @@
                     },
                     "additionalProperties": false
                 },
+                "io.k8s.api.core.v1.ResourceFieldSelector": {
+                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                    "type": "object",
+                    "required": [
+                        "resource"
+                    ],
+                    "properties": {
+                        "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                        },
+                        "divisor": {
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                        },
+                        "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "io.k8s.api.core.v1.ResourceRequirements": {
                     "description": "ResourceRequirements describes the compute resource requirements.",
                     "type": "object",
@@ -1151,6 +1285,28 @@
                         "type": {
                             "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                             "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "io.k8s.api.core.v1.SecretKeySelector": {
+                    "description": "SecretKeySelector selects a key of a Secret.",
+                    "type": "object",
+                    "required": [
+                        "key"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/helm/hello-world/values.yaml
+++ b/helm/hello-world/values.yaml
@@ -327,6 +327,31 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# @schema itemRef: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+# -- Additional environment variables to inject into the container.
+extraEnv: []
+# - name: LOG_LEVEL
+#   value: "debug"
+# - name: MY_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-secret
+#       key: token
+
+# -- Staged, deliberate failure injection for demos and testing. When enabled the
+# container leaks memory until the kubelet OOMKills it, on a loop. This is off by
+# default and must not be enabled in production.
+crash:
+  # @schema type:boolean
+  # -- Enable crash mode: a deliberate memory leak that drives a repeating OOMKill. Off by default.
+  enabled: false
+  # @schema type:integer;minimum:1
+  # -- Memory leak rate in bytes per second (default 1 MiB/s).
+  rateBytesPerSec: 1048576
+  # @schema type:string
+  # -- Grace period before leaking starts, so the pod reaches Ready first. Any Go duration.
+  gracePeriod: "30s"
+
 # @schema type:object
 # -- Node selector for pod scheduling
 nodeSelector: {}


### PR DESCRIPTION
## What

Two additions, both **off/empty by default** so rendered output is unchanged for existing users:

### `crash.enabled` — staged failure injection
A first-class toggle to opt into a deliberate, reproducible failure for demos and testing. When `crash.enabled: true`, the container is configured to leak memory until the kubelet OOMKills it, on a loop. Sane defaults are baked in and can be overridden:

```yaml
crash:
  enabled: false
  rateBytesPerSec: 1048576  # 1 MiB/s
  gracePeriod: "30s"
```

This sets the corresponding `MEMORY_LEAK_*` env vars on the container (see the companion [helloworld](https://github.com/giantswarm/helloworld/pull/170) app PR). Just `crash.enabled: true` is enough.

### `extraEnv` — generic env injection
A general-purpose value to inject arbitrary environment variables into the container (full `EnvVar` schema, so `value` and all `valueFrom` sources are supported). Defaults to `[]`.

```yaml
extraEnv:
  - name: LOG_LEVEL
    value: "debug"
```

## Notes

- With `crash.enabled: false` and `extraEnv: []` (the defaults), `helm template` output is **byte-for-byte identical** to before.
- `values.schema.json` regenerated with the pinned schema tool; `README.md` values table updated to match `helm-docs` output.
- `Chart.yaml` version intentionally not bumped — that's handled by the release automation.
- The default `crash.gracePeriod: 30s` makes the first OOM cycle ~155 s (30 s grace + ~125 s climb at 1 MiB/s / 128Mi); lower it for a tighter cadence. Note that kubelet CrashLoopBackOff stretches the spacing between kills after the first few cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)