### PR TITLE
feat: point chart at helloworld 0.7.0 (enables crash mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Add `crash` values to opt into staged failure injection for demos and testing: `crash.enabled` turns on a deliberate memory leak that drives a repeating OOMKill, with `crash.rateBytesPerSec` and `crash.gracePeriod` for tuning. Disabled by default.
 - Add `extraEnv` value to inject additional environment variables into the container. Defaults to `[]`, so rendered output is unchanged for existing users.
 
+### Changed
+
+- Update the `helloworld` image to `0.7.0` (and align `appVersion`), which ships the memory-leak support that `crash.enabled` drives.
+
 ## [3.0.4] - 2026-07-22
 
 ### Fixed

--- a/helm/hello-world/Chart.yaml
+++ b/helm/hello-world/Chart.yaml
@@ -3,7 +3,7 @@ name: hello-world
 description: A chart that deploys a basic hello world site and lets you test values merging of user values configmap and secrets.
 type: application
 version: 3.0.4
-appVersion: "0.3.0"
+appVersion: "0.7.0"
 home: https://github.com/giantswarm/hello-world-app
 icon: https://s.giantswarm.io/app-icons/1/png/hello-world-app-light.png
 keywords:

--- a/helm/hello-world/README.md
+++ b/helm/hello-world/README.md
@@ -1,6 +1,6 @@
 # hello-world
 
-![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 A chart that deploys a basic hello world site and lets you test values merging of user values configmap and secrets.
 
@@ -21,11 +21,11 @@ A chart that deploys a basic hello world site and lets you test values merging o
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ |
-| image | object | `{"name":"giantswarm/helloworld","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","tag":"0.6.0"}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
+| image | object | `{"name":"giantswarm/helloworld","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","tag":"0.7.0"}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
 | image.registry | string | `"gsoci.azurecr.io"` | Container image registry |
 | image.name | string | `"giantswarm/helloworld"` | Container image repository |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
-| image.tag | string | `"0.6.0"` | Container image tag. |
+| image.tag | string | `"0.7.0"` | Container image tag. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | nameOverride | string | `""` | This is to override the chart name. |
 | fullnameOverride | string | `""` | Override the full name of the chart |

--- a/helm/hello-world/values.yaml
+++ b/helm/hello-world/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # -- Container image tag.
-  tag: "0.6.0"
+  tag: "0.7.0"
 
 # @schema itemRef: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference
 # -- This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
## What

Bumps the referenced app image now that [giantswarm/helloworld](https://github.com/giantswarm/helloworld) `v0.7.0` is released:

- `image.tag`: `0.6.0` → **`0.7.0`** — the `0.7.0` image contains the memory-leak code, so `crash.enabled: true` actually OOM-loops. On `0.6.0` the crash-mode env vars were inert.
- `appVersion`: `0.3.0` → **`0.7.0`** — was stale; now reflects the deployed app version.
- README regenerated with helm-docs to match.

## Why now

The `crash` / `extraEnv` values were added in #269 but the chart still pointed at the pre-leak `0.6.0` image. This closes that gap so a released `3.1.0` chart is functional end-to-end.

## Verification

- `helm template` renders `image: "gsoci.azurecr.io/giantswarm/helloworld:0.7.0"`.
- `--set crash.enabled=true` still injects `MEMORY_LEAK_ENABLED/RATE/GRACE`.
- `helm lint` passes.

Once this merges, the chart release (`3.1.0`) will be re-triggered so it ships the `crash`/`extraEnv` plumbing **and** the working image together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)